### PR TITLE
Use latest gcloud SDK

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,18 +1,4 @@
-FROM debian:jessie
+FROM google/cloud-sdk
 
-ENV DEBIAN_FRONTEND noninteractive
-RUN apt-get update && apt-get install -y -qq --no-install-recommends wget unzip python php5-mysql php5-cli php5-cgi openjdk-7-jre-headless openssh-client python-openssl curl && apt-get clean
-
-RUN wget https://dl.google.com/dl/cloudsdk/release/google-cloud-sdk.zip && unzip google-cloud-sdk.zip && rm google-cloud-sdk.zip
-ENV CLOUDSDK_PYTHON_SITEPACKAGES 1
-RUN google-cloud-sdk/install.sh --usage-reporting=true --path-update=true --bash-completion=true --rc-path=/.bashrc --disable-installation-options
-RUN google-cloud-sdk/bin/gcloud --quiet components update pkg-go pkg-python pkg-java preview alpha beta app
-RUN google-cloud-sdk/bin/gcloud --quiet config set component_manager/disable_update_check true
-
-RUN mkdir /.ssh
-ENV PATH /google-cloud-sdk/bin:$PATH
-ENV HOME /
-
-ADD gcr_docker_creds.sh . 
-
-ENTRYPOINT ["./gcr_docker_creds.sh"]
+ADD gcr_docker_creds.sh /
+ENTRYPOINT ["/gcr_docker_creds.sh"]

--- a/gcr_docker_creds.sh
+++ b/gcr_docker_creds.sh
@@ -7,7 +7,7 @@ set -e
 : ${GOOGLE_PROJECT_ID:?'Set the GOOGLE_PROJECT_ID environment variable'}
 
 # Writing environment variable to Keyfile so it can be loaded later on
-echo "Logging into Google GCR"
+echo "Logging into Google Container Registry"
 echo $GOOGLE_AUTH_JSON > /keyconfig.json
 gcloud auth activate-service-account $GOOGLE_AUTH_EMAIL --key-file /keyconfig.json --project $GOOGLE_PROJECT_ID
 


### PR DESCRIPTION
The version of `gcloud` bundled with the image is extremely out-of-date now. Starting any build with the dockercfg service produces the following output:

```
build/pull started
build/pull finished successfully
Logging into Google GCR
Activated service account credentials for: [<redacted>]


Updates are available for some Cloud SDK components.  To install them,
please run:
  $ gcloud components update

Syncing GCR credentials
Loading legacy configuration file: [/.config/gcloud/properties]
This configuration file is deprecated and will not be read in a future
gcloud release.  gcloud will automatically migrate your current settings to the
new configuration format the next time you set a property by running:
  $ gcloud config set PROPERTY VALUE
You may also run:
  $ gcloud init
to create a new configuration and walk you through initializing some basic
settings.  You can find more information on named configurations by running:
  $ gcloud topic configurations

Short-lived access for ['gcr.io', 'us.gcr.io', 'eu.gcr.io', 'asia.gcr.io', 'b.gcr.io', 'bucket.gcr.io', 'appengine.gcr.io'] configured.
Writing Docker creds to /tmp/credentials/codeship-dockercfg632098100/codeship-dockercfg878872835
```
